### PR TITLE
check for session on login component

### DIFF
--- a/src/components/LoginOrSignup.tsx
+++ b/src/components/LoginOrSignup.tsx
@@ -1,7 +1,15 @@
-import { StytchB2B } from "@stytch/react/b2b";
+import { StytchB2B, useStytchMemberSession } from "@stytch/react/b2b";
 import { discoveryConfig, discoveryStyles } from '../utils/stytchConfig';
+import { Navigate } from "react-router-dom";
 
 export const LoginOrSignup = () => {
+
+  const { session } = useStytchMemberSession();
+
+  if (session) {
+    return <Navigate to="/dashboard" />;
+  }
+
 
   return (
     <div className="centered-login">


### PR DESCRIPTION
We were only checking for the session on `/authenticate` and not on `/`, so if you landed there with a logged in a session, you would be stuck and not redirected to the dashboard page. 